### PR TITLE
Fix for proper compilation on OSX

### DIFF
--- a/sasl/saslwrapper.cpp
+++ b/sasl/saslwrapper.cpp
@@ -20,7 +20,7 @@
 #include "saslwrapper.h"
 #include <sasl/sasl.h>
 #include <sstream>
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <iostream>


### PR DESCRIPTION
The malloc.h is probably too old/deprecated. Though still present at a different location in OSX, since stdlib.h includes the functions it provides, better to just switch to stdlib.h.
