### PR TITLE
Fixing ptrdiff_t compilation issues

### DIFF
--- a/sasl/saslwrapper_wrap.cxx
+++ b/sasl/saslwrapper_wrap.cxx
@@ -143,6 +143,7 @@ template <typename T> T SwigValueInit() {
 
 /* Python.h has to appear first */
 #include <Python.h>
+#include <stddef.h>
 
 /* -----------------------------------------------------------------------------
  * swigrun.swg


### PR DESCRIPTION
I was having issues installing this library on ubuntu 13.10.

```
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -Isasl -I/usr/include/python2.7 -c sasl/saslwrapper_wrap.cxx -o build/temp.linux-x86_64-2.7/sasl/saslwrapper_wrap.o
    cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++ [enabled by default]
    sasl/saslwrapper_wrap.cxx:2658:13: error: ‘ptrdiff_t’ does not name a type
         virtual ptrdiff_t distance(const PySwigIterator &/*x*/) const
                 ^
    sasl/saslwrapper_wrap.cxx:2689:21: error: expected ‘;’ at end of member declaration
         PySwigIterator *advance(ptrdiff_t n)
                         ^
    sasl/saslwrapper_wrap.cxx:2689:39: error: expected ‘)’ before ‘n’
         PySwigIterator *advance(ptrdiff_t n)
                                           ^
    sasl/saslwrapper_wrap.cxx:2704:34: error: declaration of ‘operator+=’ as non-function
         PySwigIterator& operator += (ptrdiff_t n)
 ... etc ...
```

This has happened to some other projects as well: http://goo.gl/36taW

Here is the suggested fix.
