### PR TITLE
Add rpm dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_rpm]
+requires = python >= 2.6 cyrus-sasl

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ sasl_module = Extension('_saslwrapper',
                            libraries=["sasl2"],
                            language="c++",
                            )
-dist = setup (name = 'sasl',
+dist = setup (name = 'python-sasl',
        version = '0.1.3',
        url = "http://github.com/toddlipcon/python-sasl/tree/master",
        maintainer = "Todd Lipcon",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ sasl_module = Extension('_saslwrapper',
                            libraries=["sasl2"],
                            language="c++",
                            )
-dist = setup (name = 'python-sasl',
+dist = setup (name = 'sasl',
        version = '0.1.3',
        url = "http://github.com/toddlipcon/python-sasl/tree/master",
        maintainer = "Todd Lipcon",


### PR DESCRIPTION
As packager I would like to have the needed rpm dependencies in place. So that setup.py bdist_rpm produces a valid rpm with all dependencies needed to run.